### PR TITLE
Add export functionality for items in Items controller

### DIFF
--- a/application/controllers/Items.php
+++ b/application/controllers/Items.php
@@ -1226,5 +1226,105 @@ class Items extends Secure_Controller
 			}
 		}
 	}
+
+	public function export_all()
+	{
+		// Obtener los filtros actuales
+		$filters = array(
+			'stock_location_id' => $this->item_lib->get_item_location(),
+			'empty_upc' => FALSE,
+			'low_inventory' => FALSE,
+			'is_serialized' => FALSE,
+			'no_description' => FALSE,
+			'search_custom' => FALSE,
+			'is_deleted' => FALSE,
+			'temporary' => FALSE,
+			'definition_ids' => array_keys($this->Attribute->get_definitions_by_flags(Attribute::SHOW_IN_ITEMS))
+		);
+
+		// Aplicar filtros seleccionados
+		$filledup = array_fill_keys($this->input->post('filters'), TRUE);
+		$filters = array_merge($filters, $filledup);
+
+		// Obtener todos los items usando el nuevo método
+		$items = $this->Item->get_all_for_export($filters);
+
+		// Preparar los datos para el CSV
+		$data = array();
+		$data[] = array(
+			'ID',
+			'Nombre',
+			'Categoría',
+			'ID Proveedor',
+			'Nombre Proveedor',
+			'Código',
+			'Descripción',
+			'Precio Costo',
+			'Precio Venta',
+			'Cantidad',
+			'Nivel Reorden',
+			'Cantidad Recibida',
+			'Permitir Descripción Alt',
+			'Tiene Número Serie',
+			'Imagen',
+			'Tipo Item',
+			'Tipo Stock',
+			'Impuesto 1 Nombre',
+			'Impuesto 1 Porcentaje',
+			'Impuesto 2 Nombre',
+			'Impuesto 2 Porcentaje',
+			'Categoría Impuesto',
+			'HSN'
+		);
+
+		foreach($items->result() as $item)
+		{
+			$item_taxes = $this->Item_taxes->get_info($item->item_id);
+			$tax_category = '';
+			
+			if($item->tax_category_id !== NULL)
+			{
+				$tax_category_info = $this->Tax_category->get_info($item->tax_category_id);
+				$tax_category = $tax_category_info->tax_category;
+			}
+
+			// Asegurar que todos los valores sean strings y escapar comas
+			$data[] = array(
+				(string)$item->item_id,
+				'"' . str_replace('"', '""', $item->name) . '"',
+				'"' . str_replace('"', '""', $item->category) . '"',
+				(string)$item->supplier_id,
+				'"' . str_replace('"', '""', $item->company_name) . '"',
+				'"' . str_replace('"', '""', $item->item_number) . '"',
+				'"' . str_replace('"', '""', $item->description) . '"',
+				(string)$item->cost_price,
+				(string)$item->unit_price,
+				(string)$item->quantity,
+				(string)$item->reorder_level,
+				(string)$item->receiving_quantity,
+				$item->allow_alt_description ? '1' : '0',
+				$item->is_serialized ? '1' : '0',
+				'"' . str_replace('"', '""', $item->pic_filename) . '"',
+				(string)$item->item_type,
+				(string)$item->stock_type,
+				'"' . str_replace('"', '""', isset($item_taxes[0]) ? $item_taxes[0]->name : '') . '"',
+				(string)(isset($item_taxes[0]) ? $item_taxes[0]->percent : ''),
+				'"' . str_replace('"', '""', isset($item_taxes[1]) ? $item_taxes[1]->name : '') . '"',
+				(string)(isset($item_taxes[1]) ? $item_taxes[1]->percent : ''),
+				'"' . str_replace('"', '""', $tax_category) . '"',
+				'"' . str_replace('"', '""', $item->hsn_code) . '"'
+			);
+		}
+
+		// Convertir el array a CSV
+		$csv_data = '';
+		foreach($data as $row)
+		{
+			$csv_data .= implode(',', $row) . "\n";
+		}
+		
+		// Devolver los datos en formato CSV
+		echo $csv_data;
+	}
 }
 ?>

--- a/application/controllers/Sales.php
+++ b/application/controllers/Sales.php
@@ -1833,7 +1833,7 @@ class Sales extends Secure_Controller
 			$adeudado_updated = $this->Sale->delete_adeudado_payment($sale_id);
 		} else {
 			// Si aún queda saldo pendiente, actualizar el monto adeudado
-			$adeudado_updated = $this->Sale->update_adeudado_payment($sale_id, $payment_amount);
+		$adeudado_updated = $this->Sale->update_adeudado_payment($sale_id, $payment_amount);
 		}
 
 		$this->db->trans_complete();

--- a/application/language/es/items_lang.php
+++ b/application/language/es/items_lang.php
@@ -1,4 +1,5 @@
 <?php
+$lang["common_export_all"] = "Exportar Todo el Inventario";
 $lang["items_add_minus"] = "Inventario a agregar/substraer.";
 $lang["items_allow_alt_description"] = "Permitir Descripción Alternativa";
 $lang["items_amount_entry"] = "Monto entrada";

--- a/application/models/Item.php
+++ b/application/models/Item.php
@@ -986,5 +986,64 @@ class Item extends CI_Model
 		}
 		return 'item_name';
 	}
+
+	/**
+	 * Obtiene todos los items para exportación, incluyendo información de impuestos y categorías
+	 * 
+	 * @param array $filters Filtros a aplicar
+	 * @return object Resultado de la consulta
+	 */
+	public function get_all_for_export($filters)
+	{
+		$this->db->select('items.*');
+		$this->db->select('MAX(suppliers.company_name) AS company_name');
+		$this->db->select('MAX(item_quantities.quantity) AS quantity');
+		
+		$this->db->from('items AS items');
+		$this->db->join('suppliers AS suppliers', 'suppliers.person_id = items.supplier_id', 'left');
+		$this->db->join('item_quantities AS item_quantities', 'item_quantities.item_id = items.item_id', 'left');
+		
+		if($filters['stock_location_id'] > -1)
+		{
+			$this->db->where('item_quantities.location_id', $filters['stock_location_id']);
+		}
+
+		// Aplicar filtros adicionales
+		if($filters['empty_upc'] != FALSE)
+		{
+			$this->db->where('item_number', NULL);
+		}
+		if($filters['low_inventory'] != FALSE)
+		{
+			$this->db->where('quantity <=', 'reorder_level');
+		}
+		if($filters['is_serialized'] != FALSE)
+		{
+			$this->db->where('is_serialized', 1);
+		}
+		if($filters['no_description'] != FALSE)
+		{
+			$this->db->where('items.description', '');
+		}
+		if($filters['temporary'] != FALSE)
+		{
+			$this->db->where('items.item_type', ITEM_TEMP);
+		}
+		else
+		{
+			$non_temp = array(ITEM, ITEM_KIT, ITEM_AMOUNT_ENTRY);
+			$this->db->where_in('items.item_type', $non_temp);
+		}
+
+		$this->db->where('items.deleted', $filters['is_deleted']);
+
+		// Agrupar por item_id para evitar duplicados
+		$this->db->group_by('items.item_id');
+
+		// Ordenar por nombre
+		$this->db->order_by('items.name', 'asc');
+
+		return $this->db->get();
+	}
 }
 ?>

--- a/application/views/items/manage.php
+++ b/application/views/items/manage.php
@@ -17,7 +17,7 @@ $(document).ready(function()
         table_support.refresh();
     });
 
-	// load the preset daterange picker
+	// load the preset daterangepicker
 	<?php $this->load->view('partial/daterangepicker'); ?>
     // set the beginning of time as starting date
     $('#daterangepicker').data('daterangepicker').setStartDate("<?php echo date($this->config->item('dateformat'), mktime(0,0,0,01,01,2010));?>");
@@ -29,6 +29,38 @@ $(document).ready(function()
 
     $("#stock_location").change(function() {
        table_support.refresh();
+    });
+
+    // Manejar el click del botón de exportación
+    $('.btn-info[data-href*="export_all"]').click(function(e) {
+        e.preventDefault();
+        
+        // Obtener los parámetros actuales
+        var filters = $("#filters").val() || [""];
+        var stock_location = $("#stock_location").val();
+        
+        // Hacer la llamada AJAX para obtener todos los datos
+        $.ajax({
+            url: '<?php echo site_url("items/export_all"); ?>',
+            type: 'POST',
+            data: {
+                filters: filters,
+                stock_location: stock_location
+            },
+            success: function(response) {
+                // Crear un elemento temporal para descargar el archivo
+                var element = document.createElement('a');
+                element.setAttribute('href', 'data:text/csv;charset=utf-8,' + encodeURIComponent(response));
+                element.setAttribute('download', 'items_export_' + new Date().toISOString().slice(0,10) + '.csv');
+                element.style.display = 'none';
+                document.body.appendChild(element);
+                element.click();
+                document.body.removeChild(element);
+            },
+            error: function(xhr, status, error) {
+                alert('Error al exportar los datos: ' + error);
+            }
+        });
     });
 
     <?php $this->load->view('partial/bootstrap_tables_locale'); ?>
@@ -71,6 +103,10 @@ $(document).ready(function()
 		</p>
 		<!-- End Pinto 08/04/2024 -->	
 <div id="title_bar" class="btn-toolbar print_hide">
+    <button class='btn btn-info btn-sm pull-right' data-href='<?php echo site_url("$controller_name/export_all"); ?>'
+            title='<?php echo $this->lang->line('items_export_all_items'); ?>'>
+        <span class="glyphicon glyphicon-export">&nbsp;</span><?php echo $this->lang->line('common_export_all'); ?>
+    </button>
     <button class='btn btn-info btn-sm pull-right modal-dlg' data-btn-submit='<?php echo $this->lang->line('common_submit') ?>' data-href='<?php echo site_url("$controller_name/csv_import"); ?>'
             title='<?php echo $this->lang->line('items_import_items_csv'); ?>'>
         <span class="glyphicon glyphicon-import">&nbsp;</span><?php echo $this->lang->line('common_import_csv'); ?>


### PR DESCRIPTION
- Implemented a new method `export_all` in the Items controller to export all items as a CSV file, including various item details and tax information.
- Created a new method in the Item model to retrieve items for export based on specified filters.
- Added a button in the items management view to trigger the export process via AJAX.
- Updated Spanish language file to include a new translation for the export feature.